### PR TITLE
The generator now output a node package, and the generated code can have depedencies.

### DIFF
--- a/CK.StObj.TypeScript.Engine/TSCodeWriterExtension.cs
+++ b/CK.StObj.TypeScript.Engine/TSCodeWriterExtension.cs
@@ -147,7 +147,7 @@ namespace CK.TypeScript.CodeGen
         {
             var t = type.Type;
             IPocoInterfaceInfo? iPoco;
-            var luxonLib = new LibraryImport( "luxon", "^3.0.1", DependencyKind.Dependency );
+            var luxonLib = new LibraryImport( "luxon", "^3.0.1", DependencyKind.PeerDependency );
 
             var intrinsicName = TypeScriptContext.IntrinsicTypeName( t );
             if( intrinsicName != null )

--- a/CK.StObj.TypeScript.Engine/TSCodeWriterExtension.cs
+++ b/CK.StObj.TypeScript.Engine/TSCodeWriterExtension.cs
@@ -147,6 +147,7 @@ namespace CK.TypeScript.CodeGen
         {
             var t = type.Type;
             IPocoInterfaceInfo? iPoco;
+            var luxonLib = new LibraryImport( "luxon", "^3.0.1", DependencyKind.Dependency );
 
             var intrinsicName = TypeScriptContext.IntrinsicTypeName( t );
             if( intrinsicName != null )
@@ -155,17 +156,17 @@ namespace CK.TypeScript.CodeGen
             }
             else if( t == typeof(DateTime) )
             {
-                part.File.Imports.EnsureImportFromLibrary( "luxon", "DateTime" );
+                part.File.Imports.EnsureImportFromLibrary( luxonLib, "DateTime" );
                 part.Append( "DateTime" );
             }
             else if( t == typeof( DateTimeOffset ) )
             {
-                part.File.Imports.EnsureImportFromLibrary( "luxon", "DateTime" );
+                part.File.Imports.EnsureImportFromLibrary( luxonLib, "DateTime" );
                 part.Append( "DateTime" );
             }
             else if( t == typeof( TimeSpan ) )
             {
-                part.File.Imports.EnsureImportFromLibrary( "luxon", "Duration" );
+                part.File.Imports.EnsureImportFromLibrary( luxonLib, "Duration" );
                 part.Append( "Duration" );
             }
             else if( t.IsArray )

--- a/CK.StObj.TypeScript.Engine/TypeScriptAspect.cs
+++ b/CK.StObj.TypeScript.Engine/TypeScriptAspect.cs
@@ -82,16 +82,13 @@ namespace CK.Setup
             }
             TypeScriptRoot? g;
             var binPath = genBinPath.CurrentRun;
-            var pathsAndConfig = binPath.ConfigurationGroup.SimilarConfigurations.Select( c => c.GetAspectConfiguration<TypeScriptAspect>() )
+            var pathsAndConfig = binPath.ConfigurationGroup.SimilarConfigurations
+                            .Select( c => c.GetAspectConfiguration<TypeScriptAspect>() )
                             .Where( c => c != null )
-                            .Select( c => (Config: c!, Paths: c!.Elements( "OutputPath" ).Select( p => p?.Value )
-                                                                .Where( p => !String.IsNullOrWhiteSpace( p ) )
-                                                                .Select( p => MakeAbsolute( _basePath, p ) )
-                                                                .Where( p => !p.IsEmptyPath )
-                                                                .Distinct()) )
-                            .Where( p => p.Paths.Any() )
-                            // Reverts the tuple: path => its config (potentially shared with other paths).
-                            .SelectMany( p => p.Paths.Select( onePath => (Path: onePath, p.Config) ) )
+                            .Select( c => (Path: c!.Attribute( "PackagePath" )?.Value, Config: c!) )
+                            .Where( c => !string.IsNullOrWhiteSpace( c.Path ) )
+                            .Select( c => (Path: MakeAbsolute( _basePath, c.Path ), c.Config) )
+                            .Where( c => !c.Path.IsEmptyPath )
                             .ToArray();
             if( pathsAndConfig.Length == 0 )
             {

--- a/CK.StObj.TypeScript/TypeScriptAspectBinPathConfiguration.cs
+++ b/CK.StObj.TypeScript/TypeScriptAspectBinPathConfiguration.cs
@@ -14,11 +14,10 @@ namespace CK.Setup
     {
         /// <summary>
         /// Initializes a new configuration with a default root <see cref="Barrels"/>.
-        /// At least one <see cref="OutputPaths"/> should be added.
+        /// The <see cref="PackagePath"/> must be specified.
         /// </summary>
         public TypeScriptAspectBinPathConfiguration()
         {
-            OutputPaths = new HashSet<NormalizedPath>();
             Barrels = new HashSet<NormalizedPath>
             {
                 new NormalizedPath()
@@ -26,15 +25,15 @@ namespace CK.Setup
         }
 
         /// <summary>
-        /// Gets the list of output paths. At least one path should be specified.
-        /// These OutputPaths can be absolute or start with a {BasePath}, {OutputPath} or {ProjectPath} first part: the
-        /// final paths will be resolved by <see cref="StObjEngineConfiguration.BasePath"/>, <see cref="BinPathConfiguration.OutputPath"/>
+        /// Gets the package output path.
+        /// This path can be absolute or start with a {BasePath}, {OutputPath} or {ProjectPath} first part: the
+        /// final path will be resolved by <see cref="StObjEngineConfiguration.BasePath"/>, <see cref="BinPathConfiguration.OutputPath"/>
         /// or <see cref="BinPathConfiguration.ProjectPath"/>.
         /// </summary>
-        public HashSet<NormalizedPath> OutputPaths { get; }
+        public NormalizedPath PackagePath { get; set; }
 
         /// <summary>
-        /// Gets a list of optional barrel paths that are relative to each <see cref="OutputPaths"/>.
+        /// Gets a list of optional barrel paths that are relative to the <see cref="PackagePath"/>.
         /// An index.ts file will be generated in each of these folders (see https://basarat.gitbook.io/typescript/main-1/barrel).
         /// <para>
         /// By default, an empty <see cref="NormalizedPath"/> creates a barrel at the root level.
@@ -49,8 +48,7 @@ namespace CK.Setup
         /// <param name="e">The configuration element.</param>
         public TypeScriptAspectBinPathConfiguration( XElement e )
         {
-            OutputPaths = new HashSet<NormalizedPath>( e.Elements( TypeScriptAspectConfiguration.xOutputPath )
-                                                        .Select( c => new NormalizedPath( (string?)c.Attribute( StObjEngineConfiguration.xPath ) ?? c.Value ) ) );
+            PackagePath = e.Attribute( TypeScriptAspectConfiguration.xPackagePath )?.Value;
             Barrels = new HashSet<NormalizedPath>( e.Elements( TypeScriptAspectConfiguration.xBarrels )
                                                     .Elements( TypeScriptAspectConfiguration.xBarrel )
                                                         .Select( c => new NormalizedPath( (string?)c.Attribute( StObjEngineConfiguration.xPath ) ?? c.Value ) ) );
@@ -63,10 +61,9 @@ namespace CK.Setup
         public XElement ToXml()
         {
             return new XElement( TypeScriptAspectConfiguration.xTypeScript,
-                                 OutputPaths.Select( p => new XElement( TypeScriptAspectConfiguration.xOutputPath, p ) ),
+                                 new XAttribute( TypeScriptAspectConfiguration.xPackagePath, PackagePath ),
                                  new XElement( TypeScriptAspectConfiguration.xBarrels,
                                                Barrels.Select( p => new XElement( TypeScriptAspectConfiguration.xBarrels, new XAttribute( StObjEngineConfiguration.xPath, p ) ) ) ) );
         }
-
     }
 }

--- a/CK.StObj.TypeScript/TypeScriptAspectConfiguration.cs
+++ b/CK.StObj.TypeScript/TypeScriptAspectConfiguration.cs
@@ -9,7 +9,7 @@ namespace CK.Setup
     /// Configures TypeScript generation.
     /// <para>
     /// Each <see cref="BinPathConfiguration"/> that requires TypeScript code to be generated must
-    /// contain a &lt;TypeScript&gt; element with one or more &lt;OutputPath&gt; children elements.
+    /// contain a &lt;TypeScript&gt; with the attribute &lt;PackagePath&gt;.
     /// These OutputPaths can be absolute or start with a {BasePath}, {OutputPath} or {ProjectPath} prefix: the
     /// final paths will be resolved.
     /// </para>
@@ -43,9 +43,9 @@ namespace CK.Setup
         public static readonly XName xTypeScript = XNamespace.None + "TypeScript";
 
         /// <summary>
-        /// The element name of each <see cref="TypeScriptAspectBinPathConfiguration.OutputPaths"/>.
+        /// The attribute name of <see cref="TypeScriptAspectBinPathConfiguration.PackagePath"/>.
         /// </summary>
-        public static readonly XName xOutputPath = XNamespace.None + "OutputPath";
+        public static readonly XName xPackagePath = XNamespace.None + "PackagePath";
 
         /// <summary>
         /// The <see cref="TypeScriptAspectBinPathConfiguration.Barrels"/> element name.

--- a/CK.TypeScript.CodeGen/DependencyKind.cs
+++ b/CK.TypeScript.CodeGen/DependencyKind.cs
@@ -1,0 +1,21 @@
+﻿namespace CK.TypeScript.CodeGen
+{
+    /// <summary>
+    /// Represent one of the dependencies list of the package.json.
+    /// </summary>
+    public enum DependencyKind
+    {
+        /// <summary>
+        /// The dependency will be put in the package.json devDependencies list.
+        /// </summary>
+        DevDependency,
+        /// <summary>
+        /// The dependency will be put in the package.json dependencies list.
+        /// </summary>
+        Dependency,
+        /// <summary>
+        /// The dependency will be put in the package.json peerDependencies list.
+        /// </summary>
+        PeerDependency
+    }
+}

--- a/CK.TypeScript.CodeGen/ITSFileImportSection.cs
+++ b/CK.TypeScript.CodeGen/ITSFileImportSection.cs
@@ -11,6 +11,11 @@ namespace CK.TypeScript.CodeGen
     public interface ITSFileImportSection : ITSCodeWriter
     {
         /// <summary>
+        /// Imported external library used by the generated code.
+        /// </summary>
+        IReadOnlyDictionary<string, LibraryImport> LibraryImports { get; }
+
+        /// <summary>
         /// Ensures that an import of one or more type names from the corresponding <see cref="TypeScriptFile"/> exists.
         /// </summary>
         /// <param name="file">The referenced file.</param>
@@ -22,11 +27,11 @@ namespace CK.TypeScript.CodeGen
         /// <summary>
         /// Ensures that an import of one or more type names from an external library exists.
         /// </summary>
-        /// <param name="libraryName">The library name.</param>
+        /// <param name="libraryImport">The library infos.</param>
         /// <param name="typeName">The first required type name to import.</param>
         /// <param name="typeNames">More types to import  (optionals).</param>
         /// <returns>This section to enable fluent syntax.</returns>
-        ITSFileImportSection EnsureImportFromLibrary( string libraryName, string typeName, params string[] typeNames );
+        ITSFileImportSection EnsureImportFromLibrary( LibraryImport libraryImport, string typeName, params string[] typeNames );
 
         /// <summary>
         /// Gets the number of different <see cref="EnsureImport(TypeScriptFile, string, string[])"/>

--- a/CK.TypeScript.CodeGen/InternalImpl/BaseCodeWriter.cs
+++ b/CK.TypeScript.CodeGen/InternalImpl/BaseCodeWriter.cs
@@ -55,7 +55,7 @@ namespace CK.TypeScript.CodeGen
 
         public StringBuilder Build( StringBuilder b, bool closeScope ) => Build( new SmarterStringBuilder( b ) ).Builder!;
 
-        public IDictionary<object, object?> Memory => _memory ?? (_memory = new Dictionary<object, object?>());
+        public IDictionary<object, object?> Memory => _memory ??= new Dictionary<object, object?>();
 
         public override string ToString() => Build( new SmarterStringBuilder( new StringBuilder() ) ).ToString();
     }

--- a/CK.TypeScript.CodeGen/LibraryImport.cs
+++ b/CK.TypeScript.CodeGen/LibraryImport.cs
@@ -1,0 +1,34 @@
+namespace CK.TypeScript.CodeGen
+{
+    /// <summary>
+    /// Represent an external library that the generated code depend on.
+    /// </summary>
+    public readonly struct LibraryImport
+    {
+        /// <summary>
+        /// Construct a <see cref="LibraryImport"/>.
+        /// </summary>
+        /// <param name="name">Sets <see cref="Name"/>.</param>
+        /// <param name="version">Sets <see cref="Version"/>.</param>
+        /// <param name="dependencyKind"> Sets <see cref="DependencyKind"/>. </param>
+        public LibraryImport( string name, string version, DependencyKind dependencyKind )
+        {
+            Name = name;
+            Version = version;
+            DependencyKind = dependencyKind;
+        }
+
+        /// <summary>
+        /// Name of the package name, which will be the string put in the package.json.
+        /// </summary>
+        public string Name { get; }
+        /// <summary>
+        /// Version of the package, which will be used in the package.json.
+        /// </summary>
+        public string Version { get; }
+        /// <summary>
+        /// Dependency Kind of the package, which will be used to determine in which list of the packgage.json the dependency should go.
+        /// </summary>
+        public DependencyKind DependencyKind { get; }
+    }
+}

--- a/Tests/CK.StObj.TypeScript.Tests/E2E/E2ETestContext.cs
+++ b/Tests/CK.StObj.TypeScript.Tests/E2E/E2ETestContext.cs
@@ -45,16 +45,16 @@ namespace CK.StObj.TypeScript.Tests.E2E
         {
             var collector = TestHelper.CreateStObjCollector( types );
             collector.RegisterType( typeof( PocoJsonSerializer ) );
-            var output = LocalTestHelper.GetOutputFolder( subPath, testName );
+            var packagePath = LocalTestHelper.GetOutputFolder( subPath, testName );
             var services = TestHelper.CreateAutomaticServices( collector,
-                                                               engineConfiguration => ApplyTSAwareConfig( engineConfiguration, output, tsConfig, tsBinPathConfig ),
+                                                               engineConfiguration => ApplyTSAwareConfig( engineConfiguration, packagePath, tsConfig, tsBinPathConfig ),
                                                                startupServices: null,
                                                                configureServices ).Services;
-            return new E2ETestContext( testName, output, services );
+            return new E2ETestContext( testName, packagePath, services );
         }
 
         public static StObjEngineConfiguration ApplyTSAwareConfig( StObjEngineConfiguration c,
-                                                                   NormalizedPath outputPath,
+                                                                   NormalizedPath packagePath,
                                                                    TypeScriptAspectConfiguration? tsConfig = null,
                                                                    TypeScriptAspectBinPathConfiguration? tsBinPathConfig = null )
         {
@@ -64,8 +64,10 @@ namespace CK.StObj.TypeScript.Tests.E2E
             }
             if( tsBinPathConfig == null )
             {
-                tsBinPathConfig = new TypeScriptAspectBinPathConfiguration();
-                tsBinPathConfig.OutputPaths.Add( outputPath );
+                tsBinPathConfig = new TypeScriptAspectBinPathConfiguration
+                {
+                    PackagePath = packagePath
+                };
             }
             c.Aspects.Add( tsConfig );
             c.BinPaths[0].AspectConfigurations.Add( tsBinPathConfig.ToXml() );

--- a/Tests/CK.StObj.TypeScript.Tests/EnumGenerationTests.cs
+++ b/Tests/CK.StObj.TypeScript.Tests/EnumGenerationTests.cs
@@ -31,14 +31,14 @@ namespace CK.StObj.TypeScript.Tests
             config.Aspects.Add( new TypeScriptAspectConfiguration() );
 
             var b1 = new BinPathConfiguration();
-            b1.AspectConfigurations.Add( new XElement( "TypeScript", new XElement( "OutputPath", output1 ) ) );
+            b1.AspectConfigurations.Add( new XElement( "TypeScript", new XAttribute( "PackagePath", output1 ) ) );
             var b2 = new BinPathConfiguration();
-            b2.AspectConfigurations.Add( new XElement( "TypeScript", new XElement( "OutputPath", output2 ) ) );
+            b2.AspectConfigurations.Add( new XElement( "TypeScript", new XAttribute( "PackagePath", output2 ) ) );
             // b3 has no TypeScript aspect or no OutputPath or an empty OutputPath: nothing must be generated and this is just a warning.
             var b3 = new BinPathConfiguration();
             switch( Environment.TickCount % 3 )
             {
-                case 0: b3.AspectConfigurations.Add( new XElement( "TypeScript", new XElement( "OutputPath", " " ) ) ); break;
+                case 0: b3.AspectConfigurations.Add( new XElement( "TypeScript", new XAttribute( "PackagePath", " " ) ) ); break;
                 case 1: b3.AspectConfigurations.Add( new XElement( "TypeScript" ) ); break;
             }
 
@@ -67,34 +67,6 @@ namespace CK.StObj.TypeScript.Tests
 
             var s = File.ReadAllText( f1 );
             s.Should().Contain( "export enum Simple" );
-            s.Should().Be( File.ReadAllText( f2 ) );
-        }
-
-        [Test]
-        public void each_BinPath_can_have_multiple_OutputPath()
-        {
-            var output1 = TestHelper.CleanupFolder( LocalTestHelper.OutputFolder.AppendPart( nameof( each_BinPath_can_have_multiple_OutputPath ) ).AppendPart( "o1" ), false );
-            var output2 = TestHelper.CleanupFolder( LocalTestHelper.OutputFolder.AppendPart( nameof( each_BinPath_can_have_multiple_OutputPath ) ).AppendPart( "o2" ), false );
-
-            var config = new StObjEngineConfiguration() { ForceRun = true };
-            config.Aspects.Add( new TypeScriptAspectConfiguration() );
-            var b = new BinPathConfiguration();
-            b.AspectConfigurations.Add( new XElement( "TypeScript", new XElement( "OutputPath", output1 ), new XElement( "OutputPath", output2 ) ) );
-            config.BinPaths.Add( b );
-
-            var r = TestHelper.GetSuccessfulResult( TestHelper.CreateStObjCollector( typeof( Simple ) ) );
-            StObjEngine.Run( TestHelper.Monitor, r, config ).Success.Should().BeTrue();
-
-            Directory.Exists( output1 ).Should().BeTrue();
-            Directory.Exists( output2 ).Should().BeTrue();
-
-            var f1 = output1.Combine( "CK/StObj/TypeScript/Tests/Simple.ts" );
-            var f2 = output2.Combine( "CK/StObj/TypeScript/Tests/Simple.ts" );
-            File.Exists( f1 ).Should().BeTrue();
-            File.Exists( f2 ).Should().BeTrue();
-
-            var s = File.ReadAllText( f1 );
-            s.Should().StartWith( "export enum Simple" );
             s.Should().Be( File.ReadAllText( f2 ) );
         }
 

--- a/Tests/CK.StObj.TypeScript.Tests/LocalTestHelper.cs
+++ b/Tests/CK.StObj.TypeScript.Tests/LocalTestHelper.cs
@@ -100,7 +100,7 @@ namespace CK.StObj.TypeScript.Tests
             b.CompileOption = CompileOption.Compile;
             b.ProjectPath = TestHelper.TestProjectFolder;
             b.AspectConfigurations.Add( new XElement( "TypeScript",
-                                            new XElement( "OutputPath", output ),
+                                            new XAttribute( "PackagePath", output ),
                                             new XElement( "Barrels",
                                                 new XElement( "Barrel", new XAttribute( "Path", "" ) ) ) ) );
             config.BinPaths.Add( b );


### PR DESCRIPTION
Added a LibraryImport readonly struct type.
"EnsureImportFromLibrary" now take it in parameter, instead of a string for the library name.
The `ITSFileImportSection` now exposes a `IReadOnlyDictionary<string, LibraryImport> LibraryImports { get; }.  
You can get the library imports from a `TypeScriptFile` beause it expose a `ITSFileImportSection`.  
The root `TypeScriptFolder` will generate a `package.json`, with the dependencies listed in the files.  

If there is multiple imports of the same library, a simple conflict resolution is made:  
If the version mismatch, that's an error.
The `dependencyKind` get upgraded, in the following order `devDependencies` => `dependencies` => `peerDependencies`.  

The package name is fixed to `@signature/generated`.  
If a package `library` is produced, and depend on the generated package with the name `abc`, the dependent must have the generated code with the name `abc`, if it generate `def` instaed, the node resolution will fail.  

This feature is package-manager neutral, it follow the node package.json format, it's up to the package manager that depends on the package to do the job.  